### PR TITLE
show sub command added

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+Copyright © 2021 Mahir Labib Chowdhury <optical.mahir@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #1 

Implementation of `show` subcommand to show the current ssh config file on the terminal of the user calling the function. 


*This currently assumes the path of the ssh config file, this should be collected from the user using `viper config file`*