### PR TITLE
add host command with prompt

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,0 +1,37 @@
+/*
+Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// addCmd represents the add command
+var addCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Adds a new host to the ssh config file",
+	Long:  `Adds a new host to the ssh config file`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("add called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(addCmd)
+
+}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -16,8 +16,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -26,9 +24,6 @@ var addCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Adds a new host to the ssh config file",
 	Long:  `Adds a new host to the ssh config file`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("add called")
-	},
 }
 
 func init() {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+Copyright © 2021 Mahir Labib Chowdhury <optical.mahir@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/m4hi2/ssh-config-manager-cli/pkg/parser"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 )
@@ -30,12 +31,47 @@ var promptCmd = &cobra.Command{
 	Short: "Provides a prompt to the user for adding host config interactively",
 	Long:  `Provides a prompt to the user for adding host config interactively`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("prompt called")
+		addWithPrompt()
 	},
 }
 
 func init() {
 	addCmd.AddCommand(promptCmd)
+}
+
+func addWithPrompt() {
+	hostPrompt := promptContent{
+		errorMsg: "Enter a friendly host name",
+		label:    "Host (Enter a name that you can remember for this server):",
+	}
+	host := promptGetInput(hostPrompt)
+
+	hostNamePrompt := promptContent{
+		errorMsg: "Enter the server address",
+		label:    "HostName (Enter either the IP or the domain of the server):",
+	}
+	hostName := promptGetInput(hostNamePrompt)
+
+	portPrompt := promptContent{
+		errorMsg: "Enter the ssh port nubmer of the server",
+		label:    "Port (Enter the ssh port. If not sure, enter 22):",
+	}
+	port := promptGetInput(portPrompt)
+
+	userPrompt := promptContent{
+		errorMsg: "Enter the login user name",
+		label:    "User (Enter the username to be logged in as):",
+	}
+	user := promptGetInput(userPrompt)
+
+	newConfig := parser.Config{
+		Host:     host,
+		HostName: hostName,
+		Port:     port,
+		User:     user,
+	}
+
+	fmt.Println(newConfig)
 }
 
 type promptContent struct {

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -71,8 +71,9 @@ func addWithPrompt() {
 		Port:     port,
 		User:     user,
 	}
-
-	sshconfigmanagerintenal.Add(newConfig, "config")
+	homeDir, _ := os.UserHomeDir()
+	sshConfigFilePath := fmt.Sprintf("%s/.ssh/config", homeDir)
+	sshconfigmanagerintenal.Add(newConfig, sshConfigFilePath)
 }
 
 type promptContent struct {

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -34,3 +34,8 @@ var promptCmd = &cobra.Command{
 func init() {
 	addCmd.AddCommand(promptCmd)
 }
+
+type promptContent struct {
+	errorMsg string
+	label    string
+}

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+Copyright © 2021 Mahir Labib Chowdhury <optical.mahir@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -106,7 +106,5 @@ func promptGetInput(pc promptContent) string {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Input: %s\n", result)
-
 	return result
 }

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -1,0 +1,51 @@
+/*
+Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// promptCmd represents the prompt command
+var promptCmd = &cobra.Command{
+	Use:   "prompt",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("prompt called")
+	},
+}
+
+func init() {
+	addCmd.AddCommand(promptCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// promptCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// promptCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/m4hi2/ssh-config-manager-cli/pkg/parser"
+	"github.com/m4hi2/ssh-config-manager-cli/pkg/sshconfigmanagerintenal"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 )
@@ -71,7 +72,7 @@ func addWithPrompt() {
 		User:     user,
 	}
 
-	fmt.Println(newConfig)
+	sshconfigmanagerintenal.Add(newConfig, "config")
 }
 
 type promptContent struct {

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -24,13 +24,8 @@ import (
 // promptCmd represents the prompt command
 var promptCmd = &cobra.Command{
 	Use:   "prompt",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Provides a prompt to the user for adding host config interactively",
+	Long:  `Provides a prompt to the user for adding host config interactively`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("prompt called")
 	},
@@ -38,14 +33,4 @@ to quickly create a Cobra application.`,
 
 func init() {
 	addCmd.AddCommand(promptCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// promptCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// promptCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -16,8 +16,11 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
+	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 )
 
@@ -38,4 +41,36 @@ func init() {
 type promptContent struct {
 	errorMsg string
 	label    string
+}
+
+func promptGetInput(pc promptContent) string {
+	validate := func(input string) error {
+		if len(input) <= 0 {
+			return errors.New(pc.errorMsg)
+		}
+		return nil
+	}
+
+	templates := &promptui.PromptTemplates{
+		Prompt:  "{{ . }} ",
+		Valid:   "{{ . | green }} ",
+		Invalid: "{{ . | red }} ",
+		Success: "{{ . | bold }} ",
+	}
+
+	prompt := promptui.Prompt{
+		Label:     pc.label,
+		Templates: templates,
+		Validate:  validate,
+	}
+
+	result, err := prompt.Run()
+	if err != nil {
+		fmt.Printf("Prompt failed %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Input: %s\n", result)
+
+	return result
 }

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,15 @@ require (
 )
 
 require (
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a // indirect
+	github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/manifoldco/promptui v0.8.0 // indirect
+	github.com/mattn/go-colorable v0.1.6 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mitchellh/mapstructure v1.4.2 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/spf13/afero v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,7 @@ github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqO
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -195,6 +196,8 @@ github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
+github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -202,15 +205,22 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a h1:weJVJJRzAJBFRlAiJQROKQs8oC9vOxvm4rZmBBk0ONw=
+github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
+github.com/manifoldco/promptui v0.8.0 h1:R95mMF+McvXZQ7j1g8ucVZE1gLP3Sv6j9vlF9kyRqQo=
+github.com/manifoldco/promptui v0.8.0/go.mod h1:n4zTdgP0vr0S3w7/O/g98U+e0gwLScEXGwov2nIKuGQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
@@ -403,6 +413,7 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/sshconfigmanagerintenal/sshconfigmanagerinternal.go
+++ b/pkg/sshconfigmanagerintenal/sshconfigmanagerinternal.go
@@ -18,7 +18,7 @@ func backUpFile(filePath string) {
 	backUp.Write(originalFile)
 }
 
-func add(config parser.Config, filePath string) {
+func Add(config parser.Config, filePath string) {
 	backUpFile(filePath)
 	fileContent, _ := os.ReadFile(filePath)
 	parsedConfig := parser.Parse(string(fileContent))

--- a/pkg/sshconfigmanagerintenal/sshconfigmanagerinternal.go
+++ b/pkg/sshconfigmanagerintenal/sshconfigmanagerinternal.go
@@ -11,7 +11,7 @@ import (
 func backUpFile(filePath string) {
 	originalFile, err := os.ReadFile(filePath)
 	if err != nil {
-		log.Fatalf("Can not find ssh config file\n Error: %s", err)
+		log.Printf("Can not find ssh config file\n Error: %s", err)
 	}
 
 	backUp, _ := os.Create(fmt.Sprintf("%s.bak", filePath))

--- a/pkg/sshconfigmanagerintenal/sshconfigmanagerinternal.go
+++ b/pkg/sshconfigmanagerintenal/sshconfigmanagerinternal.go
@@ -12,6 +12,7 @@ func backUpFile(filePath string) {
 	originalFile, err := os.ReadFile(filePath)
 	if err != nil {
 		log.Printf("Can not find ssh config file\n Error: %s", err)
+		log.Printf("Creating empty file as backup file...")
 	}
 
 	backUp, _ := os.Create(fmt.Sprintf("%s.bak", filePath))

--- a/pkg/sshconfigmanagerintenal/sshconfigmanagerinternal_test.go
+++ b/pkg/sshconfigmanagerintenal/sshconfigmanagerinternal_test.go
@@ -30,7 +30,7 @@ func TestLowLevelAdd(t *testing.T) {
 		Port:     "22",
 		User:     "m4hi2",
 	}
-	add(sampleConfig, "testdata/config")
+	Add(sampleConfig, "testdata/config")
 
 	fileSample, _ := os.ReadFile("testdata/config_add_sample")
 	fileAdded, _ := os.ReadFile("testdata/config")


### PR DESCRIPTION
Command to add a host to the ssh config file. 

Prompts the user for the following: 
- [x] a friendly Host name
- [x] the host IP/domain name
- [x] port nubmer
- [x] user name
